### PR TITLE
Bug fixes: exception during server creation causes exception on server deletion

### DIFF
--- a/jsontoemail/__init__.py
+++ b/jsontoemail/__init__.py
@@ -19,9 +19,6 @@ class EmailServer(object):
   def __init__(self, *args, **kwargs):
     self.server = smtplib.SMTP(*args, **kwargs)
 
-  def __del__(self):
-    self.server.quit()
-
   def send(self, email):
     response = email.should_send()
     if not isinstance(response, OK):

--- a/scripts/json-to-email
+++ b/scripts/json-to-email
@@ -5,6 +5,7 @@ import jinja2
 import os
 import smtplib
 import sys
+import time
 import datetime
 
 from argparse import ArgumentParser, ArgumentError, FileType
@@ -117,8 +118,9 @@ if __name__ == '__main__':
       message = """\
 Warning: There was an issue connecting to the SMTP server.
 Ignoring because we're in noop mode.  Further details below for info:
-%s""" % e.message
+***{message}***""".format(message=e.message)
       print >> sys.stderr, message
+      time.sleep(1)
     else:
       parser.error("Issue creating EmailServer object.  See below:\n%s" % e.message)
 

--- a/scripts/json-to-email
+++ b/scripts/json-to-email
@@ -5,7 +5,6 @@ import jinja2
 import os
 import smtplib
 import sys
-import time
 import datetime
 
 from argparse import ArgumentParser, ArgumentError, FileType
@@ -118,9 +117,9 @@ if __name__ == '__main__':
       message = """\
 Warning: There was an issue connecting to the SMTP server.
 Ignoring because we're in noop mode.  Further details below for info:
-***{message}***""".format(message=e.message)
+{message}
+""".format(message=e)
       print >> sys.stderr, message
-      time.sleep(1)
     else:
       parser.error("Issue creating EmailServer object.  See below:\n%s" % e.message)
 
@@ -142,6 +141,7 @@ Ignoring because we're in noop mode.  Further details below for info:
   if args.noop:
     response = email.should_send()
     if isinstance(response, OK):
+      print >> sys.stderr, "Would have sent the following if not in noop:"
       print email.as_string()
     else:
       print "Wouldn't send an email because: '%s: %s'" % (type(response), response.message)


### PR DESCRIPTION
If an exception is raised during server creation then EmailServer does not have a server attribute.  When it comes time to delete it, there is nothing to delete.

This was being masked because the "cannot connect" exception raised in `self.server = smtplib.SMTP(*args, **kwargs)` didn't have a message

I could make `__del__` method of `EmailServer` more complicated to cater for this case, but the connection will be closed pretty quickly anyway so I haven't bothered.